### PR TITLE
add test for overload

### DIFF
--- a/test/overload.cpp
+++ b/test/overload.cpp
@@ -4,9 +4,11 @@
 int main() {
     auto dispatcher = tl::overload(
         [](int i) { return 42; },
-        [](char const* f) { return 24; }
+        [](char const* f) { return 24; },
+        [](bool b) { return 66; }
     );
 
     assert(dispatcher(0) == 42);
     assert(dispatcher("hi") == 24);
+    assert(dispatcher(true) == 66);
 }


### PR DESCRIPTION
this test fails, because dispatcher actually calls the int overload