### PR TITLE
Add include guards

### DIFF
--- a/include/tl/casts.hpp
+++ b/include/tl/casts.hpp
@@ -11,7 +11,8 @@
 ///
 // Collection of useful casts
 ///
-
+#ifndef TL_CASTS_HPP
+#define TL_CASTS_HPP
 #include <type_traits>
 #include <cstring>
 
@@ -46,3 +47,4 @@ namespace tl {
         return static_cast<detail::safe_underlying_type_t<E>>(e);
     }
 }
+#endif

--- a/include/tl/decay_copy.hpp
+++ b/include/tl/decay_copy.hpp
@@ -11,7 +11,8 @@
 ///
 // An implementation of decay_copy: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3255.html
 ///
-
+#ifndef TL_DECAY_COPY_HPP
+#define TL_DECAY_COPY_HPP
 #include <type_traits>
 #include <utility>
 
@@ -22,4 +23,4 @@ namespace tl {
         return std::forward<T>(t);
     }
 }
-    
+#endif


### PR DESCRIPTION
Add include guards for casts.hpp and decay_copy.hpp

This prevents redefinition compilation errors if these files are included multiple times in the same source file, e.g. when including different header files that in turn pull in one of these headers.